### PR TITLE
Regarding the fixing of references between addons

### DIFF
--- a/AddonScriptLoader/ScriptCompiler.cs
+++ b/AddonScriptLoader/ScriptCompiler.cs
@@ -27,29 +27,56 @@ static public class ScriptCompiler
     {
         var lines = source.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
         var output = new StringBuilder();
-        var stack = new Stack<bool>();
-        stack.Push(true);
-        var regex = new Regex(@"^\s*#if\s+(\S+)\s*$");
+        var stack = new Stack<CondState>();
+        stack.Push(new CondState { Active = true, Taken = false });
+
+        var ifRegex = new Regex(@"^\s*#if\s+(\S+)\s*$");
+        var elifRegex = new Regex(@"^\s*#elif\s+(\S+)\s*$");
+        var elseRegex = new Regex(@"^\s*#else\s*$");
         var endifRegex = new Regex(@"^\s*#endif\s*$");
+
         foreach (var line in lines)
         {
-            var m = regex.Match(line);
-            if (m.Success)
+            Match m;
+            if ((m = ifRegex.Match(line)).Success)
             {
-                string symbol = m.Groups[1].Value;
-                bool condition = definedSymbols.Contains(symbol);
-                stack.Push(stack.Peek() && condition);
-                continue;
+                var top = stack.Peek();
+                bool cond = definedSymbols.Contains(m.Groups[1].Value);
+                bool active = top.Active && cond && !top.Taken;
+                if (active) top.Taken = true;
+                stack.Push(new CondState { Active = active, Taken = false });
             }
-            if (endifRegex.IsMatch(line))
+            else if ((m = elifRegex.Match(line)).Success)
             {
-                if (stack.Count > 1) stack.Pop();
-                continue;
+                var top = stack.Pop();
+                bool cond = definedSymbols.Contains(m.Groups[1].Value);
+                bool active = top.Active && !top.Taken && cond;
+                if (active) top.Taken = true;
+                stack.Push(new CondState { Active = active, Taken = false });
             }
-            if (stack.Peek())
+            else if (elseRegex.IsMatch(line))
+            {
+                var top = stack.Pop();
+                bool active = top.Active && !top.Taken;
+                if (active) top.Taken = true;
+                stack.Push(new CondState { Active = active, Taken = false });
+            }
+            else if (endifRegex.IsMatch(line))
+            {
+                stack.Pop();
+            }
+            else if (stack.Peek().Active)
+            {
                 output.AppendLine(line);
+            }
         }
         return output.ToString();
+    }
+
+    private class CondState
+    {
+        public bool Active;
+        public bool Taken;
     }
 
     static public Tuple<Assembly, object?>? CompileScripts(string moduleName, AssemblyLoadContext context, object[] reference, Action<int, string, int, int, string, string> logger, IEnumerable<(string source, string path)> sources, bool useHiddenMembers)

--- a/AddonScriptLoader/ScriptCompiler.cs
+++ b/AddonScriptLoader/ScriptCompiler.cs
@@ -3,13 +3,13 @@ using Microsoft.CodeAnalysis.CSharp;
 using System.Reflection;
 using System.Runtime.Loader;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace AddonScriptLoader;
 
 static public class ScriptCompiler
 {
     static private CSharpParseOptions ParseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp14);
-    //static private CSharpParseOptions ScriptParseOptions = ParseOptions.WithKind(SourceCodeKind.Script);
     static private CSharpCompilationOptions CompilationOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
             .WithUsings("Virial", "Virial.Compat", "System", "System.Linq", "System.Collections.Generic")
             .WithNullableContextOptions(NullableContextOptions.Enable)
@@ -19,11 +19,39 @@ static public class ScriptCompiler
     static public object[] SearchReferences(Assembly[] assemblies, byte[]? additionalLibrary)
     {
         var result = assemblies.Where(a => { try { return ((a.Location?.Length ?? 0) > 0); } catch { return false; } }).Select(a => MetadataReference.CreateFromFile(a.Location));
-        if(additionalLibrary != null) result = result.Append(MetadataReference.CreateFromImage(additionalLibrary));
+        if (additionalLibrary != null) result = result.Append(MetadataReference.CreateFromImage(additionalLibrary));
         return result.ToArray();
     }
 
-    //loggerは、(severity, path, line, character, id, message)の順で引数を受け取る
+    static public string PreprocessSource(string source, HashSet<string> definedSymbols)
+    {
+        var lines = source.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+        var output = new StringBuilder();
+        var stack = new Stack<bool>();
+        stack.Push(true);
+        var regex = new Regex(@"^\s*#if\s+(\S+)\s*$");
+        var endifRegex = new Regex(@"^\s*#endif\s*$");
+        foreach (var line in lines)
+        {
+            var m = regex.Match(line);
+            if (m.Success)
+            {
+                string symbol = m.Groups[1].Value;
+                bool condition = definedSymbols.Contains(symbol);
+                stack.Push(stack.Peek() && condition);
+                continue;
+            }
+            if (endifRegex.IsMatch(line))
+            {
+                if (stack.Count > 1) stack.Pop();
+                continue;
+            }
+            if (stack.Peek())
+                output.AppendLine(line);
+        }
+        return output.ToString();
+    }
+
     static public Tuple<Assembly, object?>? CompileScripts(string moduleName, AssemblyLoadContext context, object[] reference, Action<int, string, int, int, string, string> logger, IEnumerable<(string source, string path)> sources, bool useHiddenMembers)
     {
         List<SyntaxTree> trees = [];
@@ -31,48 +59,34 @@ static public class ScriptCompiler
         {
             trees.Add(CSharpSyntaxTree.ParseText(tuple.source, ParseOptions, tuple.path, Encoding.UTF8));
         }
-
-        //解析木が一つも無ければコンパイルは不要
         if (trees.Count == 0) return null;
-
         var myCompilationOptions = CompilationOptions.WithModuleName(moduleName);
-
         if (useHiddenMembers)
         {
-            //全Internal, Privateメンバにアクセスできるようにする
             var topLevelBinderFlagsProperty = typeof(CSharpCompilationOptions).GetProperty("TopLevelBinderFlags", BindingFlags.Instance | BindingFlags.NonPublic)!;
             topLevelBinderFlagsProperty.SetValue(myCompilationOptions, (uint)1 << 22);
-
             trees.Add(CSharpSyntaxTree.ParseText("[assembly: System.Runtime.CompilerServices.IgnoresAccessChecksTo(\"Nebula\")]\n[assembly: System.Runtime.CompilerServices.IgnoresAccessChecksTo(\"NebulaAPI\")]", ParseOptions, "", Encoding.UTF8));
         }
-
         var compilation = CSharpCompilation.Create(moduleName, trees, reference.Select(r => (MetadataReference)r), myCompilationOptions);
-
         Assembly? assembly = null;
         using (var stream = new MemoryStream())
         {
             var emitResult = compilation.Emit(stream);
-
             if (emitResult.Diagnostics.Length > 0)
             {
-                string log = "Compile Log:";
                 foreach (var diagnostic in emitResult.Diagnostics)
                 {
                     var pos = diagnostic.Location.GetLineSpan();
                     logger.Invoke((int)diagnostic.Severity, pos.Path, pos.StartLinePosition.Line, pos.StartLinePosition.Character, diagnostic.Id, diagnostic.GetMessage());
                 }
             }
-
             if (emitResult.Success)
             {
                 stream.Seek(0, SeekOrigin.Begin);
-                assembly = context.LoadFromStream(stream); 
-                return new (assembly, compilation.ToMetadataReference());
-            }
-            else
-            {
-                return null;
+                assembly = context.LoadFromStream(stream);
+                return new(assembly, compilation.ToMetadataReference());
             }
         }
+        return null;
     }
 }

--- a/NebulaPluginNova/Scripts/CSScript.cs
+++ b/NebulaPluginNova/Scripts/CSScript.cs
@@ -1,4 +1,5 @@
-﻿using System.IO.Compression;
+using Cpp2IL.Core.Extensions;
+using System.IO.Compression;
 using System.Reflection;
 using System.Text;
 using Virial;

--- a/NebulaPluginNova/Scripts/CSScript.cs
+++ b/NebulaPluginNova/Scripts/CSScript.cs
@@ -1,6 +1,4 @@
-﻿using Cpp2IL.Core.Extensions;
-using Iced.Intel;
-using System.IO.Compression;
+﻿using System.IO.Compression;
 using System.Reflection;
 using System.Text;
 using Virial;
@@ -12,9 +10,10 @@ internal class AddonBehaviour
 {
     [JsonSerializableField]
     public bool LoadRoles = false;
-
     [JsonSerializableField]
     public bool UseHiddenMembers = false;
+    [JsonSerializableField]
+    public List<string> References = [];
 }
 
 internal record AddonScript(Assembly Assembly, NebulaAddon Addon, object? Reference, AddonBehaviour Behaviour);
@@ -24,23 +23,19 @@ internal static class LibraryLoader
     private static ZipArchive? archive = null;
     static public byte[]? OpenLibrary(string libraryName)
     {
-        if(archive == null)
+        if (archive == null)
         {
             var libs = StreamHelper.OpenFromResource("Nebula.Resources.Libs.zip");
             archive = new ZipArchive(libs!, ZipArchiveMode.Read);
-            archive.Entries.Do(e => Debug.Log(e.FullName));
         }
-
         return archive.GetEntry("Libs/" + libraryName)?.Open().ReadBytes();
     }
-
     static public void CloseZip()
     {
         archive?.Dispose();
         archive = null;
     }
 }
-
 
 [NebulaPreprocess(PreprocessPhase.CompileAddons)]
 internal static class AddonScriptManagerLoader
@@ -51,9 +46,7 @@ internal static class AddonScriptManagerLoader
     {
         if (setUpDone) return;
         setUpDone = true;
-
         var assemblies = AppDomain.CurrentDomain.GetAssemblies();
-
         NebulaPlugin.NoSAssemblyContext.LoadFromStream(new MemoryStream(LibraryLoader.OpenLibrary("System.Collections.Immutable.dll")!));
         NebulaPlugin.NoSAssemblyContext.LoadFromStream(new MemoryStream(LibraryLoader.OpenLibrary("System.Reflection.Metadata.dll")!));
         NebulaPlugin.NoSAssemblyContext.LoadFromStream(new MemoryStream(LibraryLoader.OpenLibrary("Microsoft.CodeAnalysis.dll")!));
@@ -63,7 +56,7 @@ internal static class AddonScriptManagerLoader
         var type = loader.GetType("AddonScriptLoader.ScriptCompiler");
         CompileMethod = type?.GetMethod("CompileScripts", BindingFlags.Static | BindingFlags.Public)!;
         SearchAssembliesMethod = type?.GetMethod("SearchReferences", BindingFlags.Static | BindingFlags.Public)!;
-
+        PreprocessMethod = type?.GetMethod("PreprocessSource", BindingFlags.Static | BindingFlags.Public)!;
 #if PC
         using var apiStream = StreamHelper.OpenFromResource("Nebula.Resources.API.NebulaAPI.dll")!;
         ReferenceAssemblies = (object[])AddonScriptManagerLoader.SearchAssembliesMethod.Invoke(null, [assemblies, apiStream.ReadBytes()])!;
@@ -71,17 +64,15 @@ internal static class AddonScriptManagerLoader
         ReferenceAssemblies = (object[])AddonScriptManagerLoader.SearchAssembliesMethod.Invoke(null, [assemblies, null])!;
 #endif
     }
-
     static IEnumerator Preprocess(NebulaPreprocessor preprocessor)
     {
         Patches.LoadPatch.LoadingText = "Compiling Addon Scripts";
         yield return null;
-
         yield return AddonScriptManager.CoLoad(preprocessor);
     }
-
     static internal MethodInfo CompileMethod { get; private set; } = null!;
     static internal MethodInfo SearchAssembliesMethod { get; private set; } = null!;
+    static internal MethodInfo PreprocessMethod { get; private set; } = null!;
 }
 
 internal static class AddonScriptManager
@@ -89,7 +80,9 @@ internal static class AddonScriptManager
     static public IEnumerable<AddonScript> ScriptAssemblies => scriptAssemblies;
     static private List<AddonScript> scriptAssemblies = [];
     static private Virial.Logging.ILogger Log;
-    static private void PrintToLog(int severity, string path, int line, int character, string id, string message) {
+    static private HashSet<string> loadedAddonIds = [];
+    static private void PrintToLog(int severity, string path, int line, int character, string id, string message)
+    {
         string labeledMessage = $"{id}: {message} at {path} (Line: {line + 1}, Character: {character + 1})";
         switch (severity)
         {
@@ -105,148 +98,113 @@ internal static class AddonScriptManager
                 break;
         }
     }
+
     static public IEnumerator CoLoad(NebulaPreprocessor preprocessor)
     {
         Log = NebulaAPI.Logging.NebulaLogger("Scripting");
+        loadedAddonIds = new HashSet<string>(NebulaAddon.AllAddons.Select(a => a.Id));
 
+        var sourceUnits = new List<SourceUnit>();
         foreach (var addon in NebulaAddon.AllAddons)
         {
             string prefix = addon.InZipPath + "Scripts/";
-
-            AddonBehaviour? addonBehaviour = null;
-            var behaviour = addon.Archive.GetEntry(prefix + ".behaviour");
-            if (behaviour != null)
+            AddonBehaviour? behaviour = null;
+            var behaviourEntry = addon.Archive.GetEntry(prefix + ".behaviour");
+            if (behaviourEntry != null)
             {
-                using var stream = behaviour.Open();
-                addonBehaviour = JsonStructure.Deserialize<AddonBehaviour>(stream);
+                using var stream = behaviourEntry.Open();
+                behaviour = JsonStructure.Deserialize<AddonBehaviour>(stream);
             }
+            behaviour ??= new AddonBehaviour();
 
             var dllFiles = addon.Archive.Entries.Where(e => e.FullName.StartsWith(prefix) && e.FullName.EndsWith(".dll")).ToArray();
             if (dllFiles.Length > 0)
             {
                 yield return preprocessor.SetLoadingText("Loading Addon Scripts\n" + addon.Id);
-
                 foreach (var dll in dllFiles)
                 {
                     using var stream = dll.Open();
                     var assembly = NebulaPlugin.NoSAssemblyContext.LoadFromStream(stream);
-                    scriptAssemblies.Add(new(assembly, addon, null, addonBehaviour ?? new()));
+                    scriptAssemblies.Add(new(assembly, addon, null, behaviour));
                     NebulaAPI.Preprocessor?.PickUpPreprocess(assembly);
                 }
+                continue;
+            }
+
+            var csFiles = addon.Archive.Entries.Where(e => e.FullName.StartsWith(prefix) && e.FullName.EndsWith(".cs")).ToArray();
+            if (csFiles.Length == 0) continue;
+
+            AddonScriptManagerLoader.SetUp();
+            var sources = new List<(string source, string path)>();
+            foreach (var cs in csFiles)
+            {
+                string raw = cs.Open().ReadToEnd();
+                string pathRel = cs.FullName.Substring(prefix.Length);
+                string preprocessed = (string)AddonScriptManagerLoader.PreprocessMethod.Invoke(null, [raw, loadedAddonIds])!;
+                sources.Add((preprocessed, pathRel));
+            }
+            sourceUnits.Add(new SourceUnit(addon, behaviour, sources));
+        }
+
+        var compiled = new Dictionary<string, AddonScript>();
+        var pending = new Queue<SourceUnit>(sourceUnits);
+        int lastCount = -1;
+        while (pending.Count > 0 && pending.Count != lastCount)
+        {
+            lastCount = pending.Count;
+            var current = pending.Dequeue();
+            var references = new List<object>(AddonScriptManagerLoader.ReferenceAssemblies);
+            foreach (var refId in current.Behaviour.References)
+            {
+                if (compiled.TryGetValue(refId, out var refScript))
+                    references.Add(refScript.Reference!);
+                else if (NebulaAddon.GetAddon(refId) != null)
+                {
+                    pending.Enqueue(current);
+                    goto nextIteration;
+                }
+            }
+            yield return preprocessor.SetLoadingText("Compiling Addon Scripts\n" + current.Addon.Id);
+            var assemblyTuple = (Tuple<Assembly, object>?)AddonScriptManagerLoader.CompileMethod.Invoke(null,
+            [
+                "Script." + current.Addon.Id.HeadUpper(),
+                NebulaPlugin.NoSAssemblyContext,
+                references.ToArray(),
+                (Action<int, string, int, int, string, string>)PrintToLog,
+                current.Sources,
+                current.Behaviour.UseHiddenMembers
+            ]);
+            if (assemblyTuple == null)
+            {
+                Log.Error($"Compile Error! Scripts ignored (Addon: {current.Addon.Id})");
             }
             else
             {
-                var sources = addon.Archive.Entries.Where(e => e.FullName.StartsWith(prefix) && e.FullName.EndsWith(".cs")).Select(e => (e.Open().ReadToEnd(), e.FullName.Substring(prefix.Length))).ToArray();
-                if (sources.Length == 0) continue;
-
-                AddonScriptManagerLoader.SetUp();
-
-                yield return preprocessor.SetLoadingText("Compiling Addon Scripts\n" + addon.Id);
-
-                var assembly = (Tuple<Assembly, object>?)AddonScriptManagerLoader.CompileMethod.Invoke(null, ["Script." + addon.Id.HeadUpper(), NebulaPlugin.NoSAssemblyContext, AddonScriptManagerLoader.ReferenceAssemblies, (Action<int, string, int, int, string, string>)PrintToLog, sources, addonBehaviour?.UseHiddenMembers ?? false]);
-
-                if (assembly == null)
-                {
-                    Log.Error("Compile Error! Scripts is ignored (Addon: " + addon.Id + ")");
-                }
-                else
-                {
-                    scriptAssemblies.Add(new(assembly.Item1, addon, assembly.Item2, addonBehaviour ?? new()));
-                    NebulaAPI.Preprocessor?.PickUpPreprocess(assembly.Item1);
-                }
+                var script = new AddonScript(assemblyTuple.Item1, current.Addon, assemblyTuple.Item2, current.Behaviour);
+                scriptAssemblies.Add(script);
+                compiled[current.Addon.Id] = script;
+                NebulaAPI.Preprocessor?.PickUpPreprocess(assemblyTuple.Item1);
             }
+        nextIteration:;
         }
-
-        /*
-        var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp12);
-        var compilationOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
-            .WithUsings("Virial", "Virial.Compat", "System", "System.Linq", "System.Collections.Generic")
-            .WithNullableContextOptions(NullableContextOptions.Enable)
-            .WithOptimizationLevel(OptimizationLevel.Release)
-            .WithMetadataImportOptions(MetadataImportOptions.All);
-
-        foreach (var addon in NebulaAddon.AllAddons)
+        if (pending.Count > 0)
         {
-            string prefix = addon.InZipPath + "Scripts/";
-            
-            AddonBehaviour? addonBehaviour = null;
-            var behaviour = addon.Archive.GetEntry(prefix + ".behaviour");
-            if (behaviour != null)
-            {
-                using var stream = behaviour.Open();
-                addonBehaviour = JsonStructure.Deserialize<AddonBehaviour>(stream);
-            }
-
-            List<SyntaxTree> trees = [];
-            foreach(var entry in addon.Archive.Entries)
-            {
-                if (!entry.FullName.StartsWith(prefix)) continue;
-
-                if (entry.FullName.EndsWith(".cs"))
-                {
-                    //解析木をつくる
-                    trees.Add(CSharpSyntaxTree.ParseText(entry.Open().ReadToEnd(), parseOptions, entry.FullName.Substring(prefix.Length), Encoding.UTF8));
-                }
-            }
-            
-            //解析木が一つも無ければコンパイルは不要
-            if (trees.Count == 0) continue;
-
-            Patches.LoadPatch.LoadingText = "Compiling Addon Scripts\n" + addon.Id;
-            yield return null;
-
-            var myCompilationOptions = compilationOptions.WithModuleName("Script." + addon.Id.HeadUpper());
-
-            if (addonBehaviour?.UseHiddenMembers ?? false)
-            {
-                //全Internal, Privateメンバにアクセスできるようにする
-                var topLevelBinderFlagsProperty = typeof(CSharpCompilationOptions).GetProperty("TopLevelBinderFlags", BindingFlags.Instance | BindingFlags.NonPublic)!;
-                topLevelBinderFlagsProperty.SetValue(myCompilationOptions, (uint)1 << 22);
-
-                trees.Add(CSharpSyntaxTree.ParseText("[assembly: System.Runtime.CompilerServices.IgnoresAccessChecksTo(\"Nebula\")]\n[assembly: System.Runtime.CompilerServices.IgnoresAccessChecksTo(\"NebulaAPI\")]", parseOptions, "", Encoding.UTF8));
-            }
-
-            var compilation = CSharpCompilation.Create("Script." + addon.Id.HeadUpper(), trees, ReferenceAssemblies, myCompilationOptions)
-                .AddReferences(scriptAssemblies.Where(a => addon.Dependency.Contains(a.Addon)).Select(a => a.Reference));
-            
-            Assembly? assembly = null;
-            using (var stream = new MemoryStream())
-            {
-                var emitResult = compilation.Emit(stream);
-
-                if (emitResult.Diagnostics.Length > 0) {
-                    string log = "Compile Log:";
-                    foreach (var diagnostic in emitResult.Diagnostics)
-                    {
-                        var pos = diagnostic.Location.GetLineSpan();
-                        var location = "(" + pos.Path + " at line " + (pos.StartLinePosition.Line + 1) + ", character" + (pos.StartLinePosition.Character + 1) + ")";
-
-                        log += $"\n[{diagnostic.Severity}, {location}] {diagnostic.Id}, {diagnostic.GetMessage()}";
-                    }
-                    NebulaPlugin.Log.Print(NebulaLog.LogLevel.Log, NebulaLog.LogCategory.Scripting, log);
-                    
-                }
-
-                if (emitResult.Success)
-                {
-                    stream.Seek(0, SeekOrigin.Begin);
-                    assembly = NebulaPlugin.NoSAssemblyContext.LoadFromStream(stream); //もとはデフォルトのコンテキストでロードしていた。
-                }
-                else
-                {
-                    NebulaPlugin.Log.Print(NebulaLog.LogLevel.Error, NebulaLog.LogCategory.Scripting, "Compile Error! Scripts is ignored (Addon: " + addon.Id + ")");
-                }
-            }
-
-            if (assembly != null)
-            {
-                scriptAssemblies.Add(new(assembly, addon, compilation.ToMetadataReference(), addonBehaviour ?? new()));
-                NebulaAPI.Preprocessor?.PickUpPreprocess(assembly);
-            }
+            foreach (var unit in pending)
+                Log.Error($"Circular or missing reference detected. Addon '{unit.Addon.Id}' could not be compiled.");
         }
-        */
-
         yield break;
     }
 
+    private class SourceUnit
+    {
+        public NebulaAddon Addon;
+        public AddonBehaviour Behaviour;
+        public List<(string source, string path)> Sources;
+        public SourceUnit(NebulaAddon a, AddonBehaviour b, List<(string, string)> s)
+        {
+            Addon = a;
+            Behaviour = b;
+            Sources = s;
+        }
+    }
 }


### PR DESCRIPTION
Special handling of preprocessor directives.
#if + addonId
Automatically detect whether the corresponding addon is loaded.
At the same time, add protective handling for references between addons, allowing soft references