### PR TITLE
Player Team

### DIFF
--- a/NebulaAPI/Assignable/Role.cs
+++ b/NebulaAPI/Assignable/Role.cs
@@ -953,6 +953,9 @@ public interface RuntimeModifier : RuntimeAssignable
     DefinedModifier Modifier { get; }
     DefinedAssignable RuntimeAssignable.Assignable => Modifier;
 
+    RoleTeam? OverrideTeam => null;
+    int OverridePriority => 0;
+
     /// <summary>
     /// ゲーム開始時に割り当てられているとき、役職開示画面で表示されます。
     /// </summary>

--- a/NebulaAPI/Game/Player.cs
+++ b/NebulaAPI/Game/Player.cs
@@ -578,6 +578,7 @@ public interface Player : ICommandExecutor, IArchivedPlayer, IPlayerlike
     /// 現在割り当てられている役職です。
     /// </summary>
     RuntimeRole Role { get; }
+    RoleTeam Team { get; }
     /// <summary>
     /// 現在割り当てられている幽霊役職です。
     /// </summary>

--- a/NebulaPluginNova/Player/PlayerModInfo.cs
+++ b/NebulaPluginNova/Player/PlayerModInfo.cs
@@ -200,12 +200,29 @@ internal class PlayerModInfo : AbstractModuleContainer, IRuntimePropertyHolder, 
     public RuntimeRole Role => myRole;
     private RuntimeRole myRole = null!;
 
+    public RoleTeam Team
+    {
+        get
+        {
+            RoleTeam defaultTeam = this.Role.Role.Team;
+
+            var validModifiers = myModifiers.Where(m => m.OverrideTeam != null).ToArray();
+            if (validModifiers.Length == 0)
+                return defaultTeam;
+
+            int maxPriority = validModifiers.Max(m => m.OverridePriority);
+            var selected = validModifiers.Last(m => m.OverridePriority == maxPriority);
+            return selected.OverrideTeam ?? defaultTeam;
+        }
+    }
+
     public RuntimeGhostRole? GhostRole => myGhostRole;
     private RuntimeGhostRole? myGhostRole = null;
 
     private List<RuntimeModifier> myModifiers = new();
 
     RuntimeRole Virial.Game.Player.Role => myRole;
+    RoleTeam Virial.Game.Player.Team => this.Team;
     IEnumerable<RuntimeModifier> Virial.Game.Player.Modifiers => myModifiers;
     public Vector2 PreMeetingPoint { get; private set; } = Vector2.zero;
 


### PR DESCRIPTION
Add the RoleTeam property to Player and PlayerModInfo, and also add two properties to RuntimeModifier that can override the Team.

**OverrideTeam** ——The team covered by the modifier
**OverridePriority** ——Priority of override

In modifiers, the final result is based on priority. If two have the same priority, the override result of the last modifier is used.